### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,5 +1,9 @@
 name: labels
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/alismx/alismx/security/code-scanning/2](https://github.com/alismx/alismx/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the steps in the workflow, it appears that the `contents: read` permission is sufficient for the `actions/checkout` step, and the `issues: write` permission is likely required for the `crazy-max/ghaction-github-labeler` step. These permissions will be explicitly defined to ensure the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
